### PR TITLE
Check for touches property before deep referencing

### DIFF
--- a/src/touch-panner.js
+++ b/src/touch-panner.js
@@ -45,7 +45,9 @@ TouchPanner.prototype.resetSensor = function() {
 
 TouchPanner.prototype.onTouchStart_ = function(e) {
   // Only respond if there is exactly one touch.
-  if (e.touches.length != 1) {
+  // Note that the Daydream controller passes in a `touchstart` event with
+  // no `touches` property, so we must check for that case too.
+  if (!e.touches || e.touches.length != 1) {
     return;
   }
   this.rotateStart.set(e.touches[0].pageX, e.touches[0].pageY);


### PR DESCRIPTION
Fixes TypeError when touching Daydream trackpad caused by the fact
that Daydream controller creates an event object without a `touches`
property.

Fixes https://github.com/aframevr/aframe/issues/2669.

This commit was based on https://github.com/googlevr/webvr-polyfill/commit/4787fe5546e33bb82b9a3981245f39d9e1e136ba for a cleaner merge with https://github.com/aframevr/webvr-polyfill.

See also: corresponding PR to https://github.com/googlevr/webvr-polyfill/pull/230.